### PR TITLE
v9.0.0: Graduated disable flow with custom max-inline-disables rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This document provides comprehensive context about the `style` repository to hel
 **Repository Name:** `shaunburdick/style`
 **Purpose:** Personal ESLint configuration package for JavaScript, TypeScript, and React development
 **Package Name:** `eslint-config-shaunburdick`
-**Current Version:** 8.0.0
+**Current Version:** 9.0.0
 **License:** UNLICENSED (Public Domain)
 
 ## Project Structure
@@ -25,14 +25,16 @@ This document provides comprehensive context about the `style` repository to hel
     ├── index.js                     # Main entry point - exports all configs
     ├── es6/                         # JavaScript/ES6 base configuration
     │   ├── index.js                 # ES6 config entry point
-    │   └── rules.js                 # ES6-specific ESLint rules
+    │   ├── rules.js                 # ES6-specific ESLint rules (config + severity)
+    │   ├── custom-rules.js          # Custom ESLint rule definitions
+    │   └── custom-rules.test.js     # Tests for custom rules (co-located with source)
     ├── typescript/                  # TypeScript configuration
     │   ├── index.js                 # TypeScript config entry point
     │   └── rules.js                 # TypeScript-specific ESLint rules
     ├── react/                       # React configuration
     │   ├── index.js                 # React config entry point
     │   └── rules.js                 # React-specific ESLint rules
-    └── test/                        # Test files demonstrating proper patterns
+    └── test/                        # Pattern example files for self-linting
         ├── test.js                  # JavaScript pattern examples
         ├── test.ts                  # TypeScript pattern examples
         ├── test.tsx                 # React/TypeScript pattern examples
@@ -56,6 +58,10 @@ The package uses **ESLint Flat Config** (ESLint 10+) format and provides three m
   - `eslint-plugin-unicorn` - Modern JavaScript patterns
   - `eslint-plugin-jsdoc` - JSDoc documentation standards
   - `eslint-plugin-llm-core` - Agentic programming anti-pattern detection (file length, magic numbers, early returns, etc.)
+- **Custom Rules:** `eslint-config-shaunburdick` ships a `shaunburdick` plugin namespace with inline-defined rules in `es6/custom-rules.js`:
+  - `shaunburdick/max-inline-disables` — Warns when a file exceeds 2 inline `eslint-disable` comments, enforcing a graduated disable flow (single-line → block-level → config override)
+- **Global Linter Options:**
+  - `reportUnusedDisableDirectives: 'error'` — catches stale `eslint-disable` comments (replaces the deprecated `@eslint-community/eslint-comments/no-unused-disable` rule)
 
 ### 2. TypeScript Config (`typescript/`)
 - **Entry Point:** `typescript/index.js`
@@ -111,6 +117,7 @@ import './';                      // index
 
 See [`eslint/CHANGELOG.md`](eslint/CHANGELOG.md) for the full version history and breaking changes. Major milestones:
 
+- **v9.0.0** — Graduated disable flow, `reportUnusedDisableDirectives`, custom `shaunburdick/max-inline-disables` rule
 - **v8.0.0** — Agentic programming guardrails, `eslint-plugin-llm-core` integration, React DOM/web API security rules
 - **v7.0.0** — ESLint 10 upgrade, plugin replacements (`@eslint-react`, `import-x`, `jsx-a11y-x`), TypeScript 6.0
 - **v5.0.0** — Flat config overhaul with comprehensive plugin suite
@@ -139,6 +146,7 @@ export default [
 ### Test Strategy
 - **Self-Testing:** Package lints itself using its own configuration
 - **Pattern Files:** Test files demonstrate correct coding patterns
+- **Rule Tests:** Custom rules have unit tests using ESLint's `RuleTester` and Node.js `node:test` — tests live alongside their source (e.g., `es6/custom-rules.test.js` → `es6/custom-rules.js`)
 - **CI/CD:** GitHub Actions tests on Node.js 22.x, 24.x, 26.x (all actions pinned by commit SHA for supply chain security)
 
 ### Package Scripts
@@ -146,7 +154,8 @@ export default [
 {
   "lint": "eslint .",
   "lint:fix": "eslint . --fix",
-  "test": "npm run lint"
+  "test": "npm run lint",
+  "test:rules": "node --test es6/*.test.js"
 }
 ```
 
@@ -182,7 +191,8 @@ export default [
 2. **Adding plugin:** Update `index.js` and `package.json`
 3. **New configuration:** Create new folder structure
 4. **Version bump:** Update `package.json`, add CHANGELOG entry
-5. **Plugin renames:** `import/` → `import-x/`, `react/` → `@eslint-react/`, `jsx-a11y/` → `jsx-a11y-x/` — old `eslint-disable` prefixes silently stop working
+5. **Adding custom rule:** Define the rule in `es6/custom-rules.js`, configure it in `es6/rules.js`, wire it in `es6/index.js`, test it in `es6/custom-rules.test.js`
+6. **Plugin renames:** `import/` → `import-x/`, `react/` → `@eslint-react/`, `jsx-a11y/` → `jsx-a11y-x/` — old `eslint-disable` prefixes silently stop working
 
 ## Context for AI Agents
 
@@ -190,11 +200,13 @@ When working on this repository:
 
 1. **ESLint Knowledge Required:** Understand ESLint 10+ flat config format
 2. **Plugin Architecture:** Each config is composable and standalone
-3. **Testing Strategy:** Changes must pass self-linting
+3. **Testing Strategy:** Changes must pass self-linting; custom rules must have `RuleTester` tests alongside their source
 4. **Documentation:** All rule additions should include rationale comments
 5. **Backwards Compatibility:** Major version changes expected for new rules
 6. **Performance Consideration:** Rule additions affect all users' build times
 7. **Accessibility Focus:** React config emphasizes a11y compliance
 8. **Security Priority:** Security rules are non-negotiable requirements
+9. **Graduated Disable Flow:** Inline `eslint-disable` comments follow a graduated flow — 1-2 per file is fine, 3+ should use block-level pairs, and 3+ files with the same need should use a config override. The `shaunburdick/max-inline-disables` rule enforces the first threshold
+10. **Custom Rules:** The `shaunburdick` plugin namespace (`es6/custom-rules.js`) contains rules defined inline for this project. Rule definitions live in `custom-rules.js`, configurations in `rules.js`, wiring in `index.js`, and tests in `custom-rules.test.js`
 
 This is a foundational development tool used across multiple projects, so reliability and consistency are paramount.

--- a/eslint/CHANGELOG.md
+++ b/eslint/CHANGELOG.md
@@ -1,5 +1,15 @@
 CHANGELOG
 =========
+## 9.0.0 (2026-06-20)
+
+### Requirements Changes
+* **BREAKING:** `reportUnusedDisableDirectives: 'error'` — stale `eslint-disable` comments that were previously silently ignored now fail lint. Replace the deprecated `@eslint-community/eslint-comments/no-unused-disable` rule that was never activated
+
+### New Features — Graduated Disable Flow
+* **NEW:** `reportUnusedDisableDirectives: 'error'` — ESLint-native unused disable detection (replaces deprecated plugin rule)
+* **NEW:** `shaunburdick/max-inline-disables: warn` — custom rule enforcing the graduated disable flow: 1-2 inline disables per file is fine, 3+ should use block-level pairs, across 3+ files should use a config override
+* **NEW:** `es6/custom-rules.js` — dedicated file for inline-defined custom rules, tested alongside the source via `es6/custom-rules.test.js`
+
 ## 8.1.0 (2026-06-18)
 
 ### Changes

--- a/eslint/es6/custom-rules.js
+++ b/eslint/es6/custom-rules.js
@@ -1,0 +1,73 @@
+/**
+ * Custom ESLint rules for the shaunburdick JS config
+ *
+ * These rules are defined inline rather than imported from a plugin,
+ * tailored specifically to this project's conventions.
+ *
+ * Following the standard plugin pattern where rules are exported as
+ * a `rules` object keyed by rule name — mirrors how all ESLint
+ * plugins structure their exports.
+ */
+
+const maxInlineDisables = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Enforce graduated inline disable flow — use block-level disables for 3+ occurrences per file',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    max: {
+                        type: 'integer',
+                        minimum: 0,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+        messages: {
+            tooManyInline: [
+                'Found {{ count }} inline eslint-disable comments (max {{ max }}).',
+                'Use a block-level disable/enable pair for {{ max }}+ suppressions in the same file:',
+                '',
+                '  /* eslint-disable <rule> -- reason */',
+                '  // ... all lines needing suppression',
+                '  /* eslint-enable <rule> */',
+            ].join('\n'),
+        },
+    },
+    create(context) {
+        const max = context.options[0]?.max ?? 2;
+
+        return {
+            Program() {
+                const { sourceCode } = context;
+                const allComments = sourceCode.getAllComments();
+                const inlineDisables = allComments.filter(commentNode => {
+                    const text = commentNode.value.trim();
+
+                    return text.includes('eslint-disable-next-line')
+                        || text.includes('eslint-disable-line');
+                });
+
+                if (inlineDisables.length > max) {
+                    context.report({
+                        loc: inlineDisables[max].loc,
+                        messageId: 'tooManyInline',
+                        data: {
+                            count: String(inlineDisables.length),
+                            max: String(max),
+                        },
+                    });
+                }
+            },
+        };
+    },
+};
+
+/** @type {Record<string, import('eslint').Rule.RuleModule>} */
+export default {
+    'max-inline-disables': maxInlineDisables,
+};

--- a/eslint/es6/custom-rules.test.js
+++ b/eslint/es6/custom-rules.test.js
@@ -1,0 +1,164 @@
+/**
+ * Tests for the shaunburdick/max-inline-disables custom rule
+ *
+ * Validates the graduated disable flow:
+ * - Files with 0-2 inline eslint-disable comments are clean
+ * - Files with 3+ inline disables trigger a warning
+ * - Block-level disable/enable pairs don't count toward the limit
+ * - Custom max option overrides the default threshold
+ */
+
+import { describe, it } from 'node:test';
+import { RuleTester } from 'eslint';
+import customRules from './custom-rules.js';
+
+const RULE_NAME = 'max-inline-disables';
+const rule = customRules[RULE_NAME];
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: 12,
+        sourceType: 'module',
+    },
+});
+
+// Shared test snippets — extracted to satisfy sonarjs/no-duplicate-string
+const DISABLE_CONSOLE = '// eslint-disable-next-line no-console -- reason';
+const DISABLE_ALERT = '// eslint-disable-next-line no-alert -- reason';
+const DISABLE_DEBUG = '// eslint-disable-next-line no-debugger -- reason';
+const LOG_A = 'console.log("a");';
+const ALERT_B = 'alert("b");';
+
+describe('shaunburdick/max-inline-disables', () => {
+    it('should allow files with no eslint-disable comments', () => {
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [
+                'const x = 1;',
+                'export function add(a, b) { return a + b; }',
+            ],
+            invalid: [],
+        });
+    });
+
+    it('should allow files with 1-2 inline disables', () => {
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [
+                // 1 inline disable — under the limit
+                [
+                    '// eslint-disable-next-line no-console -- logging during development',
+                    'console.log("test");',
+                ].join('\n'),
+
+                // 2 inline disables — at the limit
+                [
+                    '// eslint-disable-next-line no-console -- logging during development',
+                    LOG_A,
+                    '// eslint-disable-next-line no-alert -- user confirmation needed',
+                    ALERT_B,
+                ].join('\n'),
+            ],
+            invalid: [],
+        });
+    });
+
+    it('should warn on files with 3+ inline disables (exceeds max of 2)', () => {
+        const threeDisables = [
+            DISABLE_CONSOLE,
+            LOG_A,
+            DISABLE_ALERT,
+            ALERT_B,
+            DISABLE_DEBUG,
+            'debugger;',
+        ].join('\n');
+
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [],
+            invalid: [
+                {
+                    code: threeDisables,
+                    options: [{ max: 2 }],
+                    errors: [
+                        {
+                            messageId: 'tooManyInline',
+                            data: { count: '3', max: '2' },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('should not count block-level disable/enable pairs', () => {
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [
+                // Block-level pair with 1 inline disable — only 1 counts
+                [
+                    '/* eslint-disable no-console -- block-level suppression */',
+                    LOG_A,
+                    'console.log("b");',
+                    '/* eslint-enable no-console */',
+                    DISABLE_ALERT,
+                    'alert("c");',
+                ].join('\n'),
+            ],
+            invalid: [],
+        });
+    });
+
+    it('should count eslint-disable-line as an inline disable', () => {
+        const threeLineDisables = [
+            'const a = 1; // eslint-disable-line no-console -- reason',
+            'const b = 2; // eslint-disable-line no-alert -- reason',
+            'const c = 3; // eslint-disable-line no-debugger -- reason',
+        ].join('\n');
+
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [],
+            invalid: [
+                {
+                    code: threeLineDisables,
+                    errors: [
+                        {
+                            messageId: 'tooManyInline',
+                            data: { count: '3', max: '2' },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('should respect a custom max option', () => {
+        const threeDisables = [
+            DISABLE_CONSOLE,
+            LOG_A,
+            DISABLE_ALERT,
+            ALERT_B,
+            DISABLE_DEBUG,
+            'debugger;',
+        ].join('\n');
+
+        ruleTester.run(RULE_NAME, rule, {
+            valid: [
+                // 3 inline disables but max is 5 — should pass
+                {
+                    code: threeDisables,
+                    options: [{ max: 5 }],
+                },
+            ],
+            invalid: [
+                // 3 inline disables with max of 2 — should fail
+                {
+                    code: threeDisables,
+                    options: [{ max: 2 }],
+                    errors: [
+                        {
+                            messageId: 'tooManyInline',
+                            data: { count: '3', max: '2' },
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/eslint/es6/index.js
+++ b/eslint/es6/index.js
@@ -9,8 +9,17 @@ import unicorn from 'eslint-plugin-unicorn';
 import comments from '@eslint-community/eslint-plugin-eslint-comments/configs';
 import llmCore from 'eslint-plugin-llm-core';
 import rules from './rules.js';
+import customRules from './custom-rules.js';
 
 export default [
+    // Global linter options — applies to all files
+    {
+        linterOptions: {
+            // Report unused eslint-disable comments (replaces deprecated
+            // @eslint-community/eslint-comments/no-unused-disable)
+            reportUnusedDisableDirectives: 'error',
+        },
+    },
     js.configs.recommended,
     comments.recommended,
     security.configs.recommended,
@@ -29,7 +38,10 @@ export default [
             sonarjs,
             unicorn,
             'import-x': importXPlugin,
-            'llm-core': llmCore
+            'llm-core': llmCore,
+            'shaunburdick': {
+                rules: customRules,
+            },
         },
         rules
     },
@@ -43,6 +55,8 @@ export default [
                 ignore: [0, 1, 2, 3, 4, 5, 10, 12, 15, 120],
                 ignoreObjectProperties: true,
             }],
+            // Bypass max-inline-disables for config files which may need exemptions
+            'shaunburdick/max-inline-disables': 'off',
         }
     }
 ];

--- a/eslint/es6/rules.js
+++ b/eslint/es6/rules.js
@@ -226,6 +226,11 @@ export default Object.freeze({
     // https://eslint-community.github.io/eslint-plugin-eslint-comments/rules/require-description.html
     '@eslint-community/eslint-comments/require-description': ['error'],
 
+    // enforce the graduated disable flow: warn when a file exceeds 2 inline
+    // eslint-disable comments, suggesting a block-level pair instead,
+    // defined in ./custom-rules.js
+    'shaunburdick/max-inline-disables': ['warn', { max: 2 }],
+
     // require or disallow semicolons instead of ASI, https://eslint.style/rules/default/semi
     '@stylistic/semi': ['error'],
 

--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-config-shaunburdick",
-    "version": "8.1.0",
+    "version": "9.0.0",
     "description": "Shaun's style configuration",
     "main": "index.js",
     "type": "module",
@@ -14,7 +14,8 @@
         "fix": "npm run lint:fix",
         "lint:fix": "eslint . --fix",
         "lint": "eslint .",
-        "test": "npm run lint"
+        "test:rules": "node --test es6/*.test.js",
+        "test": "npm run lint && npm run test:rules"
     },
     "keywords": [
         "typescript",


### PR DESCRIPTION
## Summary

Implements the graduated eslint-disable flow with two enforcement mechanisms:

### Breaking Changes

- **`reportUnusedDisableDirectives: 'error'`** — stale `eslint-disable` comments that were previously silently ignored now fail lint. This is ESLint-native and replaces the deprecated `@eslint-community/eslint-comments/no-unused-disable` plugin rule (which was never activated in this config).

### New Features

- **`shaunburdick/max-inline-disables: warn`** — custom rule that warns when a file exceeds 2 inline `eslint-disable` comments, enforcing the graduated flow:
  1. 0–2 inline disables → clean (default)
  2. 3+ inline disables → warn, suggesting a block-level disable/enable pair
  3. 3+ files with same need → config override instead

### Custom Rule Infrastructure

- New `es6/custom-rules.js` — inline-defined ESLint rules under the `shaunburdick` plugin namespace
- New `es6/custom-rules.test.js` — co-located tests using `RuleTester` + Node.js `node:test`
- Updated `npm test` to run both self-lint and rule tests

### Documentation

- Updated `AGENTS.md` with project structure, custom rules info, graduated disable flow guidance
- Updated `CHANGELOG.md` with v9.0.0 entry

---

Resolves the graduated disable flow enforcement (steps 1-2 of the graduated disable policy).